### PR TITLE
Update flags.m4

### DIFF
--- a/common/autoconf/flags.m4
+++ b/common/autoconf/flags.m4
@@ -857,7 +857,7 @@ AC_DEFUN([FLAGS_CXX_COMPILER_CHECK_ARGUMENTS],
   supports=yes
 
   saved_cxxflags="$CXXFLAGS"
-  CXXFLAGS="$CXXFLAG $1"
+  CXXFLAGS="$CXXFLAGS $1"
   AC_LANG_PUSH([C++])
   AC_COMPILE_IFELSE([AC_LANG_SOURCE([[int i;]])], [], 
       [supports=no])


### PR DESCRIPTION
In FLAGS_CXX_COMPILER_CHECK_ARGUMENTS, CXXFLAG is used instead of CXXFLAGS, so the options are not properly passed. For example, when building 32-bit JDK on a 64-bit system, "-m32" is not passed as a C++ option in some tests, so configure fails.